### PR TITLE
[add] solargraphをセットアップ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ yarn-debug.log*
 
 # Ignore .env files
 *.env
+
+# Ignore config files for solargraph
+/config/definitions.rb
+.solargraph.yml


### PR DESCRIPTION
## 概要

solargraphを使用できるようにセットアップし、その際に作成したファイルを
Gitの管理対象外にした。

### 詳細

/config/definitions.rb, /.solargraph.ymlを作成し、.gitignoreに以下の設定をした。

```diff
.gitignore

+ # Ignore config files for solargraph
+ /config/definitions.rb
+ .solargraph.yml
```