### PR TITLE
[fix] Semantic UI導入時の設定ミスを修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,5 +13,3 @@
  *= require_tree .
  *= require_self
  */
-
- @import "semantic-ui";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,1 @@
+ @import "semantic-ui";


### PR DESCRIPTION
## 概要

`semantic-ui-sass` 導入時に設定を記述するファイルに誤りがあったため修正した。

## 詳細

Semantic UIのスタイルを使用するために、app/assets/stylesheets/application.scss に
`@import "semantic-ui";` を記述するが、誤ってapp/assets/stylesheets/application.css
に記述していたため修正した。
