### PR TITLE
[add] Google Books APIでの書籍検索機能と書籍・所蔵の登録機能

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache --virtual build-deps \
         yarn \
         tzdata \
         imagemagick6-dev \
+        less \
         git \
     && rm -rf /usr/lib/libmysqld* \
     && rm -rf /usr/bin/mysql*

--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -42,5 +42,44 @@ module Admin
 
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
+
+    def create
+      resource = resource_class.new(resource_params)
+      authorize_resource(resource)
+
+      if resource.save
+        create_collection(resource)
+        redirect_to(
+          [namespace, resource],
+          notice: translate_with_resource("create.success")
+        )
+      else
+        render :new, locals: {
+          page: Administrate::Page::Form.new(dashboard, resource)
+        }
+      end
+    end
+
+    def search
+      google_book_data = GoogleBook.search(params[:keyword])
+      resource = resource_class.new
+      resource = resource.substitute_for_googlebook(google_book_data)
+      authorize_resource(resource)
+
+      render :new, locals: {
+        page: Administrate::Page::Form.new(dashboard, resource)
+      }
+    end
+
+    private
+
+    def create_collection(resource)
+      quantities = resource.quantity
+
+      quantities.times do |quantity|
+        collection_code = "#{resource.id}-#{quantity + 1}"
+        resource.collections.create(collection_code: collection_code)
+      end
+    end
   end
 end

--- a/app/dashboards/book_dashboard.rb
+++ b/app/dashboards/book_dashboard.rb
@@ -12,7 +12,6 @@ class BookDashboard < Administrate::BaseDashboard
     id: Field::Number,
     title: Field::String,
     author: Field::String,
-    publisher: Field::String,
     published_date: Field::String,
     isbn_10: Field::Number,
     isbn_13: Field::Number,
@@ -31,7 +30,6 @@ class BookDashboard < Administrate::BaseDashboard
     id
     title
     author
-    publisher
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -40,7 +38,6 @@ class BookDashboard < Administrate::BaseDashboard
     id
     title
     author
-    publisher
     published_date
     isbn_10
     isbn_13
@@ -57,7 +54,6 @@ class BookDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     title
     author
-    publisher
     published_date
     isbn_10
     isbn_13

--- a/app/lib/google_book.rb
+++ b/app/lib/google_book.rb
@@ -1,0 +1,46 @@
+class GoogleBook
+  attr_reader :googlebooksapi_id, :title, :author, :published_date, :isbn10, :isbn13, :description
+
+  class << self
+    include GoogleBooksApi
+
+    def new_from_id(googlebooksapi_id)
+      url = url_of_creating_from_id(googlebooksapi_id)
+      item = get_json_from_url(url)
+      new(item)
+    end
+
+    def search(keyword)
+      url = url_of_searching_from_keyword(keyword)
+      json = get_json_from_url(url)
+      item = json["items"].first
+
+      new(item) if item.present?
+    end
+  end
+
+  def initialize(item)
+    @item = item
+    @volume_info = @item["volumeInfo"]
+    retrieve_attribute
+    retrieve_attribute_isbn
+  end
+
+  def retrieve_attribute
+    @title = @volume_info["title"]
+    @author = @volume_info["authors"]
+    @published_date = @volume_info["publishedDate"]
+    @description = @volume_info["description"]
+  end
+
+  def retrieve_attribute_isbn
+    @industry_identifiers = @volume_info["industryIdentifiers"]
+    if @industry_identifiers[0]["type"] == "ISBN_10"
+      @isbn10 = @volume_info["industryIdentifiers"][0]["identifier"]
+      @isbn13 = @volume_info["industryIdentifiers"][1]["identifier"]
+    else
+      @isbn10 = @volume_info["industryIdentifiers"][1]["identifier"]
+      @isbn13 = @volume_info["industryIdentifiers"][0]["identifier"]
+    end
+  end
+end

--- a/app/lib/google_books_api.rb
+++ b/app/lib/google_books_api.rb
@@ -1,0 +1,16 @@
+module GoogleBooksApi
+  # URLから、JSON文字列を取得し、JSONオブジェクトを返す
+  def get_json_from_url(url)
+    JSON.parse(Net::HTTP.get(URI.parse(Addressable::URI.encode(url))))
+  end
+
+  # キーワードから検索時に叩くAPIのURLを取得する
+  def url_of_searching_from_keyword(keyword)
+    "https://www.googleapis.com/books/v1/volumes?q=#{keyword}&country=JP&maxResults=20"
+  end
+
+  # Google Books APIのIDから、APIのURLを取得する
+  def url_of_creating_from_id(googlebooksapi_id)
+    "https://www.googleapis.com/books/v1/volumes/#{googlebooksapi_id}"
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,7 +4,6 @@ class Book < ApplicationRecord
   validates :title, presence: true,
                     uniqueness: true
   validates :author, presence: true
-  validates :publisher, presence: true
   validates :published_date, presence: true,
                              length: { maximum: 10 }
   validates :isbn_10, numericality: { only_integer: true },
@@ -17,4 +16,14 @@ class Book < ApplicationRecord
                       uniqueness: true
   validates :quantity, presence: true,
                        numericality: { only_integer: true }
+
+  def substitute_for_googlebook(google_book)
+    self.title = google_book.title
+    self.author = google_book.author
+    self.published_date = google_book.published_date
+    self.isbn_10 = google_book.isbn10
+    self.isbn_13 = google_book.isbn13
+    self.description = google_book.description
+    self
+  end
 end

--- a/app/policies/book_policy.rb
+++ b/app/policies/book_policy.rb
@@ -26,4 +26,8 @@ class BookPolicy < ApplicationPolicy
   def destroy?
     user.admin?
   end
+
+  def search?
+    user.admin?
+  end
 end

--- a/app/views/admin/books/_search_form.html.erb
+++ b/app/views/admin/books/_search_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(url: search_admin_books_path, method: :get, local: true) do |f| %>
+  <%= f.text_field :keyword %>
+  <%= f.submit "書籍情報取得" %>
+<% end %>

--- a/app/views/admin/books/new.html.erb
+++ b/app/views/admin/books/new.html.erb
@@ -1,0 +1,38 @@
+<%#
+# New
+
+This view is the template for the "new resource" page.
+It displays a header, and then renders the `_form` partial
+to do the heavy lifting.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<% content_for(:title) do %>
+  <%= t(
+    "administrate.actions.new_resource",
+    name: display_resource_name(page.resource_name).titleize
+  ) %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to t("administrate.actions.back"), :back, class: "button" %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <%= render "search_form", page: page %>
+  <%= render "form", page: page %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users
     resources :departments
-    resources :books
+    resources :books do
+      get "search", on: :collection
+    end
 
     root to: "users#index"
   end

--- a/db/migrate/20200922185451_create_books.rb
+++ b/db/migrate/20200922185451_create_books.rb
@@ -3,7 +3,6 @@ class CreateBooks < ActiveRecord::Migration[6.0]
     create_table :books do |t|
       t.string :title, null: false, default: ""
       t.string :author, null: false, default: ""
-      t.string :publisher, null: false, default: ""
       t.string :published_date, null: false, default: ""
       t.bigint :isbn_10
       t.bigint :isbn_13

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 2020_09_22_222347) do
   create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.string "title", default: "", null: false
     t.string "author", default: "", null: false
-    t.string "publisher", default: "", null: false
     t.string "published_date", default: "", null: false
     t.bigint "isbn_10"
     t.bigint "isbn_13"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,7 +89,6 @@ end
 50.times do |n|
   title = "#{Faker::Book.title} #{n + 1}"
   author = Faker::Book.author
-  publisher = Faker::Book.publisher
   published_date = "2019-01-01"
   isbn10 = 4_000_000_000 + n + 1
   isbn13 = 9_000_000_000_000 + n + 1
@@ -98,7 +97,6 @@ end
   Book.create!(
     title: title,
     author: author,
-    publisher: publisher,
     published_date: published_date,
     isbn_10: isbn10,
     isbn_13: isbn13,

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :book do
     title { "テスト書籍" }
     author { "テスト著者名" }
-    publisher { "テスト出版社" }
     published_date { "2019-01-01" }
     isbn_10 { 4_000_000_001 }
     isbn_13 { 9_000_000_000_001 }

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -42,20 +42,6 @@ RSpec.describe Book, type: :model do
     end
   end
 
-  describe "'publisher' validations" do
-    context "when 'publisher' is empty" do
-      before { book.publisher = "" }
-
-      it { is_expected.to be_invalid }
-    end
-
-    context "when 'publisher' is not empty" do
-      before { book.publisher = "not empty" }
-
-      it { is_expected.to be_valid }
-    end
-  end
-
   describe "'published_date' validations" do
     context "when 'published_date' is empty" do
       before { book.published_date = "" }


### PR DESCRIPTION
## 概要

書籍新規登録の際にGoogle Books APIで書籍情報を取得し、フォームに自動入力される機能と、
書籍データ作成時に所蔵データも作成するようadministrateのcreateメソッドをオーバーライドした。

またGoogle Books APIで取得した書籍情報では出版社が取得できないこと、現状では出版社の情報が必要では
ないことの2点より、booksテーブルから `publisher` を削除した。

## 追加対応

Alpine Linuxでは `less` をインストールしないとRailsコンソールでデータがうまく表示できないため、
Dockerfileに追記した。